### PR TITLE
Uniform putXXX specification description

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Hatoholサーバー                                   HAP
 
 ### putItems(method)
 
- - Hatoholサーバーとの接続完了時，または[fetchItems](#user-content-fetchitemsmethod)プロシージャのリクエストをHatoholサーバーから受け取った時に全てのアイテム情報を送信することを標準動作とします。Hatoholサーバーの負荷が高くなることが危惧されるため，任意のタイミングで使用することはできません。
+ - Hatoholサーバーとの接続完了時，または[fetchItems](#user-content-fetchitemsmethod)プロシージャのリクエストをHatoholサーバーから受け取った時に全てのアイテム情報をHatoholサーバーへ送信することを標準動作とします。Hatoholサーバーの負荷が高くなることが危惧されるため，任意のタイミングで使用することはできません。
 
 ***リクエスト(params)***
 


### PR DESCRIPTION
`putItems` プロシージャのみHatoholサーバーへの語句がなかったので少し混乱してしまいました。
他の`putXXX` 系のプロシージャは送信先がプロシージャの説明へ書かれているのですが、これだけありませんでした。

詳細に書くとしたら「HAPからHatoholサーバーへ」、となりますが、これはその前に説明があるので省いています。
