### PR TITLE
Fix wrong examples of itemGroupName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Hatoholサーバー                                   HAP
     "items": [
       {
         "unit": "example unit",
-        "itemGroupName": "example name",
+        "itemGroupName": ["example name"],
         "lastValue": "example value",
         "lastValueTime": "20150410175500",
         "brief": "example brief",
@@ -363,7 +363,7 @@ Hatoholサーバー                                   HAP
       },
       {
         "unit": "example unit",
-        "itemGroupName": "example name",
+        "itemGroupName": ["example name", "network", "building-E1"],
         "lastValue": "example value",
         "lastValueTime": "201504101755",
         "brief": "example brief",

--- a/en/README.md
+++ b/en/README.md
@@ -356,7 +356,7 @@ Standard behavior is to send all item information to Hatohol server when complet
     "items": [
       {
         "unit": "example unit",
-        "itemGroupName": "example name",
+        "itemGroupName": ["example name"],
         "lastValue": "example value",
         "lastValueTime": "20150410175500",
         "brief": "example brief",
@@ -365,7 +365,7 @@ Standard behavior is to send all item information to Hatohol server when complet
       },
       {
         "unit": "example unit",
-        "itemGroupName": "example name",
+        "itemGroupName": ["example name", "network", "building-E1"],
         "lastValue": "example value",
         "lastValueTime": "201504101755",
         "brief": "example brief",


### PR DESCRIPTION
According to the specification, itemGroupName shall be an array of string.
